### PR TITLE
Update AlbiteStreamReader.java

### DIFF
--- a/src/org/albite/io/decoders/AlbiteStreamReader.java
+++ b/src/org/albite/io/decoders/AlbiteStreamReader.java
@@ -76,6 +76,9 @@ public class AlbiteStreamReader extends Reader {
                 /*
                  * EOF
                  */
+                if (i == 0) {
+            		return -1;
+            	}
                 return i;
             }
 


### PR DESCRIPTION
Fixed bug where AlbiteStreamReader.read would return 0 instead of -1 when EOF was reached.